### PR TITLE
パブリックのaddressesコントローラ作り直し

### DIFF
--- a/app/assets/stylesheets/public/addresses.scss
+++ b/app/assets/stylesheets/public/addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/addresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -1,8 +1,18 @@
-class Public::Addresses　indexController < ApplicationController
+class Public::AddressesController < ApplicationController
 
   def index
   end
 
   def edit
   end
+
+  def create
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
 end

--- a/app/helpers/public/addresses_helper.rb
+++ b/app/helpers/public/addresses_helper.rb
@@ -1,0 +1,2 @@
+module Public::AddressesHelper
+end

--- a/app/views/public/addresses/edit.html.erb
+++ b/app/views/public/addresses/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::Addresses　index#edit</h1>
-<p>Find me in app/views/public/addresses　index/edit.html.erb</p>

--- a/test/controllers/public/addresses_controller_test.rb
+++ b/test/controllers/public/addresses_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::AddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
アドレスコントローラの作り直し
前に、パブリックのアドレスcontrollerのファイル名にindexがついていたのをただ消しただけだったからエラーが出たので、
コマンドで削除し、再度、作り直した。