### PR TITLE
fix-addresses

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -1,5 +1,7 @@
 class Public::AddressesController < ApplicationController
-
+  
+  before_action :correct_customer, only: [:edit, :update]
+  
   def index
     @address = Address.new
     @addresses = Address.all
@@ -44,5 +46,10 @@ class Public::AddressesController < ApplicationController
   def address_params
     params.require(:address).permit(:postcode, :address, :name)
   end
-
+  
+  def correct_customer
+    @address = Address.find(params[:id])
+    @customer = @address.customer
+    redirect_to addresses_path unless @customer == current_customer
+  end
 end

--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -23,22 +23,22 @@
       </thead>
       <tbody>
       <% @addresses.each do |address| %>
+        <% if address.customer == current_customer %>
         <tr>
           <td class="align-middle">
             <%= address.postcode %>
           </td>
-          <td>
+          <td class="align-middle">
             <%= address.address %>
           </td>
           <td class="align-middle">
             <%= address.name %>
           </td>
-          <% if address.customer == current_customer %>
-            <td>
-              <%= link_to "編集する", edit_address_path(current_customer), class:"btn btn-success" %>
-              <%= link_to "削除する", address_path(address) , method: :delete, "data-confirm" => "本当に消しますか？" ,class: "btn btn-danger" %>
-            </td>
-          <% end %>  
+          <td>
+            <%= link_to "編集する", edit_address_path(current_customer), class:"btn btn-success" %>
+            <%= link_to "削除する", address_path(address) , method: :delete, "data-confirm" => "本当に消しますか？" ,class: "btn btn-danger" %>
+          </td>
+        <% end %>  
         </tr>
       <% end %>  
       </tbody>


### PR DESCRIPTION
他人の配送先の編集画面に遷移できないようにしました。また、登録しているユーザーのすべての情報を表示されていたため、ログインしているユーザーの配送先情報だけを表示させるようにしました。